### PR TITLE
track usage of clips with a simple persisted hash-object

### DIFF
--- a/discordieTest.js
+++ b/discordieTest.js
@@ -6,7 +6,27 @@ var fs = require('fs');
 var config = JSON.parse(fs.readFileSync('Discord.config'))
 var audioList = {};
 
+// set up data persistance
+const storage = require("node-persist");
+var usage = {};
+function setupStorage() {
+    await storage.init();
+    // clip usage: hash of name => counter
+    usage = await storage.getItem("usage");
+    if (!usage) {
+        usage = {};
+        await storage.setItem("usage", usage);
+    }
+}
+function incrementUsage(name) {
+    if (!usage[name]) {
+        usage[name] = 0;
+    }
+    usage[name] += 1;
+    await storage.setItem("usage", usage);
+}
 
+setupStorage();
 
 client.connect({
   // replace this sample token
@@ -111,6 +131,8 @@ function play(message) {
 		message.reply("Audio Clip " + playCommand + " Not Found");
 		return;
 	}
+
+	incrementUsage(playCommand);
 
 	var mp3decoder = new lame.Decoder();
 	mp3decoder.on('format', decode);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 
     "dependencies": {
         "lame": "~1.2.4",
-        "discordie": "~0.11.0"
+        "discordie": "~0.11.0",
+        "node-persist": "~3.0.1"
     },
     "engineStrict":true,
     "engines":{


### PR DESCRIPTION
track usage of clips with a simple hash-object, persisted via node-persist (https://github.com/simonlast/node-persist)

after there is some data can adjust `audiolist` to pull top X records by counter and make a separate `fullaudiolist` command?

i don't have npm installed so i can't test this. node-persist examples used `await` which i've never used in js.